### PR TITLE
Restyle using development version of styler

### DIFF
--- a/R/between_within.R
+++ b/R/between_within.R
@@ -37,11 +37,11 @@ within_i <- function(.var, .df = get(".", envir = parent.frame()), .fcn = functi
 
 
   # Pull out variable names
-  .icall <- tidyselect::vars_select(names(.df), {{.i}})
+  .icall <- tidyselect::vars_select(names(.df), {{ .i }})
   if (length(.icall) == 0) {
     .icall <- NA_character_
   }
-  .tcall <- tidyselect::vars_select(names(.df), {{.t}})
+  .tcall <- tidyselect::vars_select(names(.df), {{ .t }})
   if (length(.tcall) == 0) {
     .tcall <- NA_character_
   }
@@ -95,11 +95,11 @@ between_i <- function(.var, .df = get(".", envir = parent.frame()), .fcn = funct
   .df <- .df
 
   # Pull out variable names
-  .icall <- tidyselect::vars_select(names(.df), {{.i}})
+  .icall <- tidyselect::vars_select(names(.df), {{ .i }})
   if (length(.icall) == 0) {
     .icall <- NA_character_
   }
-  .tcall <- tidyselect::vars_select(names(.df), {{.t}})
+  .tcall <- tidyselect::vars_select(names(.df), {{ .t }})
   if (length(.tcall) == 0) {
     .tcall <- NA_character_
   }

--- a/R/inexact_join.R
+++ b/R/inexact_join.R
@@ -64,19 +64,11 @@ NULL
 #' @export
 inexact_inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ..., var = NULL, jvar = NULL, method, exact = TRUE) {
   # Pull out variable names
-  jvarcall <- tidyselect::vars_select(names(y), {
-    {
-      jvar
-    }
-  })
+  jvarcall <- tidyselect::vars_select(names(y), {{ jvar }})
   if (length(jvarcall) == 0) {
     jvarcall <- NA_character_
   }
-  varcall <- tidyselect::vars_select(names(x), {
-    {
-      var
-    }
-  })
+  varcall <- tidyselect::vars_select(names(x), {{ var }})
   if (length(varcall) == 0) {
     varcall <- NA_character_
   }
@@ -99,19 +91,11 @@ inexact_inner_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", "
 #' @export
 inexact_left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ..., var = NULL, jvar = NULL, method, exact = TRUE) {
   # Pull out variable names
-  jvarcall <- tidyselect::vars_select(names(y), {
-    {
-      jvar
-    }
-  })
+  jvarcall <- tidyselect::vars_select(names(y), {{ jvar }})
   if (length(jvarcall) == 0) {
     jvarcall <- NA_character_
   }
-  varcall <- tidyselect::vars_select(names(x), {
-    {
-      var
-    }
-  })
+  varcall <- tidyselect::vars_select(names(x), {{ var }})
   if (length(varcall) == 0) {
     varcall <- NA_character_
   }
@@ -134,19 +118,11 @@ inexact_left_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".
 #' @export
 inexact_right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ..., var = NULL, jvar = NULL, method, exact = TRUE) {
   # Pull out variable names
-  jvarcall <- tidyselect::vars_select(names(y), {
-    {
-      jvar
-    }
-  })
+  jvarcall <- tidyselect::vars_select(names(y), {{ jvar }})
   if (length(jvarcall) == 0) {
     jvarcall <- NA_character_
   }
-  varcall <- tidyselect::vars_select(names(x), {
-    {
-      var
-    }
-  })
+  varcall <- tidyselect::vars_select(names(x), {{ var }})
   if (length(varcall) == 0) {
     varcall <- NA_character_
   }
@@ -170,19 +146,11 @@ inexact_right_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", "
 #' @export
 inexact_full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ..., var = NULL, jvar = NULL, method, exact = TRUE) {
   # Pull out variable names
-  jvarcall <- tidyselect::vars_select(names(y), {
-    {
-      jvar
-    }
-  })
+  jvarcall <- tidyselect::vars_select(names(y), {{ jvar }})
   if (length(jvarcall) == 0) {
     jvarcall <- NA_character_
   }
-  varcall <- tidyselect::vars_select(names(x), {
-    {
-      var
-    }
-  })
+  varcall <- tidyselect::vars_select(names(x), {{ var }})
   if (length(varcall) == 0) {
     varcall <- NA_character_
   }
@@ -205,19 +173,11 @@ inexact_full_join <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".
 #' @export
 inexact_semi_join <- function(x, y, by = NULL, copy = FALSE, ..., var = NULL, jvar = NULL, method, exact = TRUE) {
   # Pull out variable names
-  jvarcall <- tidyselect::vars_select(names(y), {
-    {
-      jvar
-    }
-  })
+  jvarcall <- tidyselect::vars_select(names(y), {{ jvar }})
   if (length(jvarcall) == 0) {
     jvarcall <- NA_character_
   }
-  varcall <- tidyselect::vars_select(names(x), {
-    {
-      var
-    }
-  })
+  varcall <- tidyselect::vars_select(names(x), {{ var }})
   if (length(varcall) == 0) {
     varcall <- NA_character_
   }
@@ -241,19 +201,11 @@ inexact_semi_join <- function(x, y, by = NULL, copy = FALSE, ..., var = NULL, jv
 #' @export
 inexact_nest_join <- function(x, y, by = NULL, copy = FALSE, keep = FALSE, name = NULL, ..., var = NULL, jvar = NULL, method, exact = TRUE) {
   # Pull out variable names
-  jvarcall <- tidyselect::vars_select(names(y), {
-    {
-      jvar
-    }
-  })
+  jvarcall <- tidyselect::vars_select(names(y), {{ jvar }})
   if (length(jvarcall) == 0) {
     jvarcall <- NA_character_
   }
-  varcall <- tidyselect::vars_select(names(x), {
-    {
-      var
-    }
-  })
+  varcall <- tidyselect::vars_select(names(x), {{ var }})
   if (length(varcall) == 0) {
     varcall <- NA_character_
   }
@@ -276,19 +228,11 @@ inexact_nest_join <- function(x, y, by = NULL, copy = FALSE, keep = FALSE, name 
 #' @export
 inexact_anti_join <- function(x, y, by = NULL, copy = FALSE, ..., var = NULL, jvar = NULL, method, exact = TRUE) {
   # Pull out variable names
-  jvarcall <- tidyselect::vars_select(names(y), {
-    {
-      jvar
-    }
-  })
+  jvarcall <- tidyselect::vars_select(names(y), {{ jvar }})
   if (length(jvarcall) == 0) {
     jvarcall <- NA_character_
   }
-  varcall <- tidyselect::vars_select(names(x), {
-    {
-      var
-    }
-  })
+  varcall <- tidyselect::vars_select(names(x), {{ var }})
   if (length(varcall) == 0) {
     varcall <- NA_character_
   }

--- a/R/major_mutate_variations.R
+++ b/R/major_mutate_variations.R
@@ -46,19 +46,11 @@ mutate_cascade <- function(.df, ..., .skip = TRUE, .backwards = FALSE, .group_i 
   }
 
   # Pull out variable names
-  .icall <- tidyselect::vars_select(names(.df), {
-    {
-      .i
-    }
-  })
+  .icall <- tidyselect::vars_select(names(.df), {{ .i }})
   if (length(.icall) == 0) {
     .icall <- NA_character_
   }
-  .tcall <- tidyselect::vars_select(names(.df), {
-    {
-      .t
-    }
-  })
+  .tcall <- tidyselect::vars_select(names(.df), {{ .t }})
   if (length(.tcall) == 0) {
     .tcall <- NA_character_
   }
@@ -71,15 +63,7 @@ mutate_cascade <- function(.df, ..., .skip = TRUE, .backwards = FALSE, .group_i 
 
   # Panel-declare data if any changes have been made.
   if (min(is.na(.icall)) == 0 | !is.na(.tcall) | !is.na(.d)) {
-    .df <- as_pibble(.df, {
-      {
-        .i
-      }
-    }, {
-      {
-        .t
-      }
-    }, .d, .uniqcheck = .uniqcheck)
+    .df <- as_pibble(.df, {{ .i }}, {{ .t }}, .d, .uniqcheck = .uniqcheck)
 
     # .d might be unspecified and so inp$d is NA, but now .d is 1 from as_pibble default
     inp$d <- .df %@% ".d"
@@ -179,19 +163,11 @@ mutate_subset <- function(.df, ..., .filter, .group_i = TRUE, .i = NULL, .t = NU
   }
 
   # Pull out variable names
-  .icall <- tidyselect::vars_select(names(.df), {
-    {
-      .i
-    }
-  })
+  .icall <- tidyselect::vars_select(names(.df), {{ .i }})
   if (length(.icall) == 0) {
     .icall <- NA_character_
   }
-  .tcall <- tidyselect::vars_select(names(.df), {
-    {
-      .t
-    }
-  })
+  .tcall <- tidyselect::vars_select(names(.df), {{ .t }})
   if (length(.tcall) == 0) {
     .tcall <- NA_character_
   }
@@ -200,15 +176,7 @@ mutate_subset <- function(.df, ..., .filter, .group_i = TRUE, .i = NULL, .t = NU
 
   # Panel-declare data if any changes have been made.
   if (min(is.na(.icall)) == 0 | !is.na(.tcall) | !is.na(.d)) {
-    .df <- as_pibble(.df, {
-      {
-        .i
-      }
-    }, {
-      {
-        .t
-      }
-    }, .d = .d, .uniqcheck = .uniqcheck)
+    .df <- as_pibble(.df, {{ .i }}, {{ .t }}, .d = .d, .uniqcheck = .uniqcheck)
 
     # .d might be unspecified and so inp$d is NA, but now .d is 1 from as_pibble default
     inp$d <- .df %@% ".d"
@@ -222,11 +190,7 @@ mutate_subset <- function(.df, ..., .filter, .group_i = TRUE, .i = NULL, .t = NU
 
   # Perform the summary on the subset
   summ <- .df %>%
-    dplyr::filter({
-      {
-        .filter
-      }
-    }) %>%
+    dplyr::filter({{ .filter }}) %>%
     dplyr::summarize(...)
   # See what variables were created not counting the groupings
   # First, get the grouping variables

--- a/R/panel_consistency.R
+++ b/R/panel_consistency.R
@@ -22,26 +22,26 @@
 #' @param .setpanel Logical parameter. Set to FALSE to return data with the same \code{.i}, \code{.t}, \code{.d} attributes it came in with, even if those are null. TRUE by default, but ignored if \code{.i}, \code{.t}, and \code{.d} are all NA.
 #' @examples
 #'
-#'   data(Scorecard)
-#'   # Notice that, in the Scorecard data, the gap between one year and the next is not always constant
-#'   table((Scorecard %>% dplyr::arrange(year) %>%
-#'     dplyr::group_by(unitid) %>%
-#'     dplyr::mutate(diff = year - dplyr::lag(year)))$diff)
-#'   # And also that not all universities show up for the first or last times in the same year
-#'   year_range <- Scorecard %>%
-#'     dplyr::group_by(unitid) %>%
-#'     dplyr::summarize(first_year = min(year), last_year = max(year))
-#'   table(year_range$first_year)
-#'   table(year_range$last_year)
-#'   rm(year_range)
+#' data(Scorecard)
+#' # Notice that, in the Scorecard data, the gap between one year and the next is not always constant
+#' table((Scorecard %>% dplyr::arrange(year) %>%
+#'   dplyr::group_by(unitid) %>%
+#'   dplyr::mutate(diff = year - dplyr::lag(year)))$diff)
+#' # And also that not all universities show up for the first or last times in the same year
+#' year_range <- Scorecard %>%
+#'   dplyr::group_by(unitid) %>%
+#'   dplyr::summarize(first_year = min(year), last_year = max(year))
+#' table(year_range$first_year)
+#' table(year_range$last_year)
+#' rm(year_range)
 #'
-#'   # We can deal with the inconsistent-gaps problem by creating new obs to fill in
-#'   # this version will fill in the new obs with the most recently observed data, and flag them
-#'   Scorecard_filled <- panel_fill(Scorecard,
-#'     .i = unitid,
-#'     .t = year,
-#'     .flag = "new"
-#'   )
+#' # We can deal with the inconsistent-gaps problem by creating new obs to fill in
+#' # this version will fill in the new obs with the most recently observed data, and flag them
+#' Scorecard_filled <- panel_fill(Scorecard,
+#'   .i = unitid,
+#'   .t = year,
+#'   .flag = "new"
+#' )
 #'
 #' # Additional examples too slow to run
 #' if (interactive()) {
@@ -89,11 +89,11 @@ panel_fill <- function(.df, .set_NA = FALSE, .min = NA, .max = NA, .backwards = 
   }
 
   # Pull out variable names
-  .icall <- tidyselect::vars_select(names(.df), {{.i}})
+  .icall <- tidyselect::vars_select(names(.df), {{ .i }})
   if (length(.icall) == 0) {
     .icall <- NA_character_
   }
-  .tcall <- tidyselect::vars_select(names(.df), {{.t}})
+  .tcall <- tidyselect::vars_select(names(.df), {{ .t }})
   if (length(.tcall) == 0) {
     .tcall <- NA_character_
   }
@@ -113,7 +113,7 @@ panel_fill <- function(.df, .set_NA = FALSE, .min = NA, .max = NA, .backwards = 
 
   # Panel-declare data if any changes have been made.
   if (min(is.na(.icall)) == 0 | !is.na(.tcall)) {
-    .df <- as_pibble(.df, {{.i}}, {{.t}}, .d, .uniqcheck = .uniqcheck)
+    .df <- as_pibble(.df, {{ .i }}, {{ .t }}, .d, .uniqcheck = .uniqcheck)
 
     # .d might be unspecified and so inp$d is NA, but now .d is 1 from as_pibble default
     inp$d <- .df %@% ".d"
@@ -203,8 +203,11 @@ panel_fill <- function(.df, .set_NA = FALSE, .min = NA, .max = NA, .backwards = 
   #-1 for the original copy. Make it IN the data b/c I'll need group structure in a sec
   .df[, ncol(.df) + 1] <- .df[[inp$t]]
   copyname <- names(.df)[ncol(.df)]
-  .df <- .df %>% dplyr::mutate_at(copyname, .funs =
-                                    function(x) abs(x - dplyr::lead(x)) / inp$d - 1) %>%
+  .df <- .df %>%
+    dplyr::mutate_at(copyname,
+      .funs =
+        function(x) abs(x - dplyr::lead(x)) / inp$d - 1
+    ) %>%
     dplyr::mutate_at(copyname, .funs = list(. = ~ dplyr::case_when(
       is.na(.) | is.infinite(.) ~ 0,
       TRUE ~ .
@@ -374,11 +377,11 @@ panel_locf <- function(.var, .df = get(".", envir = parent.frame()), .fill = NA,
   .df <- .df
 
   # Pull out variable names
-  .icall <- tidyselect::vars_select(names(.df), {{.i}})
+  .icall <- tidyselect::vars_select(names(.df), {{ .i }})
   if (length(.icall) == 0) {
     .icall <- NA_character_
   }
-  .tcall <- tidyselect::vars_select(names(.df), {{.t}})
+  .tcall <- tidyselect::vars_select(names(.df), {{ .t }})
   if (length(.tcall) == 0) {
     .tcall <- NA_character_
   }
@@ -515,19 +518,11 @@ fixed_check <- function(.df, .var = NULL, .within = NULL) {
   }
 
   # Pull out variable names
-  .varcall <- tidyselect::vars_select(names(.df), {
-    {
-      .var
-    }
-  })
+  .varcall <- tidyselect::vars_select(names(.df), {{ .var }})
   if (length(.varcall) == 0) {
     .icall <- NA_character_
   }
-  .withincall <- tidyselect::vars_select(names(.df), {
-    {
-      .within
-    }
-  })
+  .withincall <- tidyselect::vars_select(names(.df), {{ .within }})
   if (length(.withincall) == 0) {
     .withincall <- NA_character_
   }
@@ -601,19 +596,11 @@ fixed_force <- function(.df, .var = NULL, .within = NULL, .resolve = function(x)
   }
 
   # Pull out variable names
-  .varcall <- tidyselect::vars_select(names(.df), {
-    {
-      .var
-    }
-  })
+  .varcall <- tidyselect::vars_select(names(.df), {{ .var }})
   if (length(.varcall) == 0) {
     .icall <- NA_character_
   }
-  .withincall <- tidyselect::vars_select(names(.df), {
-    {
-      .within
-    }
-  })
+  .withincall <- tidyselect::vars_select(names(.df), {{ .within }})
   if (length(.withincall) == 0) {
     .withincall <- NA_character_
   }

--- a/R/pibble.R
+++ b/R/pibble.R
@@ -63,11 +63,11 @@ pibble <- function(..., .i = NULL, .t = NULL, .d = 1, .uniqcheck = FALSE) {
   tbl <- tibble::tibble(...)
 
   # Pull out variable names; build_pibble takes strings
-  .i <- tidyselect::vars_select(names(tbl), {{.i}})
+  .i <- tidyselect::vars_select(names(tbl), {{ .i }})
   if (length(.i) == 0) {
     .i <- NA_character_
   }
-  .t <- tidyselect::vars_select(names(tbl), {{.t}})
+  .t <- tidyselect::vars_select(names(tbl), {{ .t }})
   if (length(.t) == 0) {
     .t <- NA_character_
   }
@@ -167,11 +167,11 @@ as_pibble.tbl_df <- function(x,
                              ...) {
 
   # Pull out variable names; build_pibble takes strings
-  .i <- tidyselect::vars_select(names(x), {{.i}})
+  .i <- tidyselect::vars_select(names(x), {{ .i }})
   if (length(.i) == 0) {
     .i <- NA_character_
   }
-  .t <- tidyselect::vars_select(names(x), {{.t}})
+  .t <- tidyselect::vars_select(names(x), {{ .t }})
   if (length(.t) == 0) {
     .t <- NA_character_
   }

--- a/R/tlag.R
+++ b/R/tlag.R
@@ -113,11 +113,11 @@ tlag <- function(.var, .df = get(".", envir = parent.frame()), .n = 1, .default 
   }
 
   # Pull out variable names
-  .icall <- tidyselect::vars_select(names(.df), {{.i}})
+  .icall <- tidyselect::vars_select(names(.df), {{ .i }})
   if (length(.icall) == 0) {
     .icall <- NA_character_
   }
-  .tcall <- tidyselect::vars_select(names(.df), {{.t}})
+  .tcall <- tidyselect::vars_select(names(.df), {{ .t }})
   if (length(.tcall) == 0) {
     .tcall <- NA_character_
   }


### PR DESCRIPTION
The CRAN version of styler messed up the curly-curly (`{{`) bits of the code. This PR restyles the package's code using `usethis::use_tidy_style()` and the development version of styler. 