### PR TITLE
Add URL to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-8333-1256")))
 Description: Using the dplyr package as a base, adds a family of functions designed to make manipulating panel data easier. Allows the addition of indexing variables to a tibble, and the manipulation of data based on those indexing variables.
 License: MIT + file LICENSE
+URL: https://github.com/NickCH-K/pmdplyr
 Encoding: UTF-8
 Depends: R (>= 2.15.1),
         dplyr (>= 0.7.0)

--- a/docs/404.html
+++ b/docs/404.html
@@ -81,7 +81,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -81,7 +81,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -81,7 +81,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,7 +47,14 @@
   <a href="reference/index.html">Reference</a>
 </li>
       </ul>
-<ul class="nav navbar-nav navbar-right"></ul>
+<ul class="nav navbar-nav navbar-right">
+<li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
+      </ul>
 </div>
 <!--/.nav-collapse -->
   </div>
@@ -103,7 +110,14 @@
   </div>
 
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-    <div class="license">
+    <div class="links">
+<h2>Links</h2>
+<ul class="list-unstyled">
+<li>Browse source code at <br><a href="https://github.com/NickCH-K/pmdplyr">https://​github.com/​NickCH-K/​pmdplyr</a>
+</li>
+</ul>
+</div>
+<div class="license">
 <h2>License</h2>
 <ul class="list-unstyled">
 <li>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,4 +1,4 @@
-pandoc: '2.6'
+pandoc: 2.7.2
 pkgdown: 1.3.0.9100
 pkgdown_sha: 1829398a4e97056fe7fb332d0e8b952784b49321
 articles: []

--- a/docs/reference/SPrail.html
+++ b/docs/reference/SPrail.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>2,000 Spanish train trips</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/data.R'><code>R/data.R</code></a></small>
     <div class="hidden name"><code>SPrail.Rd</code></div>
     </div>
 

--- a/docs/reference/Scorecard.html
+++ b/docs/reference/Scorecard.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Earnings and Loan Repayment in US Four-Year Colleges</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/data.R'><code>R/data.R</code></a></small>
     <div class="hidden name"><code>Scorecard.Rd</code></div>
     </div>
 

--- a/docs/reference/as_pibble.html
+++ b/docs/reference/as_pibble.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Coerce to a pibble panel data set object</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/pibble.R'><code>R/pibble.R</code></a></small>
     <div class="hidden name"><code>as_pibble.Rd</code></div>
     </div>
 

--- a/docs/reference/build_pibble.html
+++ b/docs/reference/build_pibble.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Low-level constructor for a pibble object</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/pibble.R'><code>R/pibble.R</code></a></small>
     <div class="hidden name"><code>build_pibble.Rd</code></div>
     </div>
 

--- a/docs/reference/fixed_check.html
+++ b/docs/reference/fixed_check.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Check for inconsistency in variables that should be fixed</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/panel_consistency.R'><code>R/panel_consistency.R</code></a></small>
     <div class="hidden name"><code>fixed_check.Rd</code></div>
     </div>
 

--- a/docs/reference/fixed_force.html
+++ b/docs/reference/fixed_force.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Enforce consistency in variables</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/panel_consistency.R'><code>R/panel_consistency.R</code></a></small>
     <div class="hidden name"><code>fixed_force.Rd</code></div>
     </div>
 

--- a/docs/reference/id_variable.html
+++ b/docs/reference/id_variable.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Create a single panel ID variable out of several</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/id_variable.R'><code>R/id_variable.R</code></a></small>
     <div class="hidden name"><code>id_variable.Rd</code></div>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -81,7 +81,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->

--- a/docs/reference/inexact_join.html
+++ b/docs/reference/inexact_join.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Join two data frames inexactly</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/inexact_join.R'><code>R/inexact_join.R</code></a></small>
     <div class="hidden name"><code>inexact_join.Rd</code></div>
     </div>
 

--- a/docs/reference/is_pibble.html
+++ b/docs/reference/is_pibble.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Check whether an object has been declared as panel data</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/pibble.R'><code>R/pibble.R</code></a></small>
     <div class="hidden name"><code>is_pibble.Rd</code></div>
     </div>
 

--- a/docs/reference/mutate_cascade.html
+++ b/docs/reference/mutate_cascade.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Perform mutate one time period at a time ('Cascading mutate')</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/major_mutate_variations.R'><code>R/major_mutate_variations.R</code></a></small>
     <div class="hidden name"><code>mutate_cascade.Rd</code></div>
     </div>
 

--- a/docs/reference/mutate_subset.html
+++ b/docs/reference/mutate_subset.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Propogate a calculation performed on a subset of data to the rest of the data</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/major_mutate_variations.R'><code>R/major_mutate_variations.R</code></a></small>
     <div class="hidden name"><code>mutate_subset.Rd</code></div>
     </div>
 

--- a/docs/reference/panel_calculations.html
+++ b/docs/reference/panel_calculations.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Perform standard panel-data calculations</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/between_within.R'><code>R/between_within.R</code></a></small>
     <div class="hidden name"><code>panel_calculations.Rd</code></div>
     </div>
 

--- a/docs/reference/panel_convert.html
+++ b/docs/reference/panel_convert.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Convert between panel data types</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/panel_convert.R'><code>R/panel_convert.R</code></a></small>
     <div class="hidden name"><code>panel_convert.Rd</code></div>
     </div>
 

--- a/docs/reference/panel_fill.html
+++ b/docs/reference/panel_fill.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Fill in gaps in panel data</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/panel_consistency.R'><code>R/panel_consistency.R</code></a></small>
     <div class="hidden name"><code>panel_fill.Rd</code></div>
     </div>
 

--- a/docs/reference/panel_locf.html
+++ b/docs/reference/panel_locf.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Fill in missing (or other) values of a panel data set using known data</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/panel_consistency.R'><code>R/panel_consistency.R</code></a></small>
     <div class="hidden name"><code>panel_locf.Rd</code></div>
     </div>
 

--- a/docs/reference/pibble.html
+++ b/docs/reference/pibble.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Create a pibble panel data set object</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/pibble.R'><code>R/pibble.R</code></a></small>
     <div class="hidden name"><code>pibble.Rd</code></div>
     </div>
 

--- a/docs/reference/pibble_methods.html
+++ b/docs/reference/pibble_methods.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>pibble methods</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/tbl_pb_methods.R'><code>R/tbl_pb_methods.R</code></a></small>
     <div class="hidden name"><code>pibble_methods.Rd</code></div>
     </div>
 

--- a/docs/reference/pipe.html
+++ b/docs/reference/pipe.html
@@ -85,7 +85,12 @@ See magrittr::pipe for details." />
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -100,7 +105,7 @@ See magrittr::pipe for details." />
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Pipe operator</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/utils-pipe.R'><code>R/utils-pipe.R</code></a></small>
     <div class="hidden name"><code>pipe.Rd</code></div>
     </div>
 

--- a/docs/reference/pmdplyr.html
+++ b/docs/reference/pmdplyr.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1><code>pmdplyr</code> package</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/pmdplyr.R'><code>R/pmdplyr.R</code></a></small>
     <div class="hidden name"><code>pmdplyr.Rd</code></div>
     </div>
 

--- a/docs/reference/safe_join.html
+++ b/docs/reference/safe_join.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Join two data frames safely</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/inexact_join.R'><code>R/inexact_join.R</code></a></small>
     <div class="hidden name"><code>safe_join.Rd</code></div>
     </div>
 

--- a/docs/reference/time_variable.html
+++ b/docs/reference/time_variable.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Create a single integer time period index variable</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/time_variable.R'><code>R/time_variable.R</code></a></small>
     <div class="hidden name"><code>time_variable.Rd</code></div>
     </div>
 

--- a/docs/reference/tlag.html
+++ b/docs/reference/tlag.html
@@ -84,7 +84,12 @@
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="https://github.com/NickCH-K/pmdplyr">
+    <span class="fab fa fab fa-github fa-lg"></span>
+     
+  </a>
+</li>
       </ul>
       
     </div><!--/.nav-collapse -->
@@ -99,7 +104,7 @@
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Time-lag a variable</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/NickCH-K/pmdplyr/blob/master/R/tlag.R'><code>R/tlag.R</code></a></small>
     <div class="hidden name"><code>tlag.Rd</code></div>
     </div>
 


### PR DESCRIPTION
This small PR adds the GitHub repo link to the DESCRIPTION file so that the GitHub icon is exposed in the top right corner of the pkgdown site. 