### PR TITLE
Run CI tests on specific versions of R

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^codecov\.yml$
 ^README\.Rmd$
 ^\.github$
+^\.covrignore$

--- a/.covrignore
+++ b/.covrignore
@@ -1,0 +1,2 @@
+R/deprec-*.R
+R/compat-*.R

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,11 @@
+---
+name: Bug report or feature request
+about: Describe a bug you've seen or make a case for a new feature
+---
+
 Please briefly describe your problem and what output you expect. If you have a question, please don't use this form. Instead, ask on <https://stackoverflow.com/> or <https://community.rstudio.com/>.
 
-Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](https://reprex.tidyverse.org/) before, start by reading <https://www.tidyverse.org/help/#reprex>.
-
----
+Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](http://reprex.tidyverse.org/) before, start by reading <https://www.tidyverse.org/help/#reprex>.
 
 Brief description of the problem
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,25 @@
 language: R
 cache: packages
 
+matrix:
+  include:
+  - r: devel
+  - r: release
+    after_success:
+    - Rscript -e 'covr::codecov()'
+  - r: oldrel
+  - r: 3.4
+  - r: 3.3
+  - r: 3.2
+
+## Test environments
+
+* local: mingw32-3.6.1
+* travis: 3.1, 3.2, 3.3, oldrel, release, devel
+* r-hub: windows-x86_64-devel, ubuntu-gcc-release, fedora-clang-devel
+* win-builder: windows-x86_64-devel
+
+## R CMD check results
+
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
     - Rscript -e 'covr::codecov()'
   - r: oldrel
   - r: 3.4
-  - r: 3.3
-  - r: 3.2
 
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,5 @@ matrix:
   - r: 3.3
   - r: 3.2
 
-## Test environments
-
-* local: mingw32-3.6.1
-* travis: 3.1, 3.2, 3.3, oldrel, release, devel
-* r-hub: windows-x86_64-devel, ubuntu-gcc-release, fedora-clang-devel
-* win-builder: windows-x86_64-devel
-
-## R CMD check results
-
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,9 @@ Description: Using the dplyr package as a base, adds a family of functions desig
 License: MIT + file LICENSE
 URL: https://github.com/NickCH-K/pmdplyr
 Encoding: UTF-8
-Depends: R (>= 2.15.1),
-        dplyr (>= 0.7.0)
+Depends: 
+    R (>= 3.2),
+    dplyr (>= 0.7.0)
 Imports:
     lubridate,
     magrittr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,9 +11,10 @@ Authors@R: c(
 Description: Using the dplyr package as a base, adds a family of functions designed to make manipulating panel data easier. Allows the addition of indexing variables to a tibble, and the manipulation of data based on those indexing variables.
 License: MIT + file LICENSE
 URL: https://github.com/NickCH-K/pmdplyr
+BugReports: https://github.com/NickCH-K/pmdplyr/issues
 Encoding: UTF-8
 Depends: 
-    R (>= 3.2),
+    R (>= 3.4),
     dplyr (>= 0.7.0)
 Imports:
     lubridate,

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,8 @@
+  ## Test environments
+
+  * local: mingw32-3.6.1
+  * travis: 3.1, 3.2, 3.3, oldrel, release, devel
+  * r-hub: windows-x86_64-devel, ubuntu-gcc-release, fedora-clang-devel
+  * win-builder: windows-x86_64-devel
+
+  ## R CMD check results

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,7 @@
   ## Test environments
   
   * local: mingw32-3.6.1
-  * travis: 3.1, 3.2, 3.3, oldrel, release, devel
+  * travis: oldrel, release, devel
   * r-hub: windows-x86_64-devel, ubuntu-gcc-release, fedora-clang-devel
   * win-builder: windows-x86_64-devel
   

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,7 @@
   ## Test environments
   
   * local: mingw32-3.6.1
-  * travis: oldrel, release, devel
+  * travis: 3.4, oldrel, release, devel
   * r-hub: windows-x86_64-devel, ubuntu-gcc-release, fedora-clang-devel
   * win-builder: windows-x86_64-devel
   

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,8 +1,8 @@
   ## Test environments
-
+  
   * local: mingw32-3.6.1
   * travis: 3.1, 3.2, 3.3, oldrel, release, devel
   * r-hub: windows-x86_64-devel, ubuntu-gcc-release, fedora-clang-devel
   * win-builder: windows-x86_64-devel
-
+  
   ## R CMD check results

--- a/docs/ISSUE_TEMPLATE.html
+++ b/docs/ISSUE_TEMPLATE.html
@@ -107,9 +107,10 @@
     </div>
 
 
-<p>Please briefly describe your problem and what output you expect. If you have a question, please don’t use this form. Instead, ask on <a href="https://stackoverflow.com/" class="uri">https://stackoverflow.com/</a> or <a href="https://community.rstudio.com/" class="uri">https://community.rstudio.com/</a>.</p>
-<p>Please include a minimal reproducible example (AKA a reprex). If you’ve never heard of a <a href="https://reprex.tidyverse.org/">reprex</a> before, start by reading <a href="https://www.tidyverse.org/help/#reprex" class="uri">https://www.tidyverse.org/help/#reprex</a>.</p>
 <hr>
+<p>name: Bug report or feature request about: Describe a bug you’ve seen or make a case for a new feature —</p>
+<p>Please briefly describe your problem and what output you expect. If you have a question, please don’t use this form. Instead, ask on <a href="https://stackoverflow.com/" class="uri">https://stackoverflow.com/</a> or <a href="https://community.rstudio.com/" class="uri">https://community.rstudio.com/</a>.</p>
+<p>Please include a minimal reproducible example (AKA a reprex). If you’ve never heard of a <a href="http://reprex.tidyverse.org/">reprex</a> before, start by reading <a href="https://www.tidyverse.org/help/#reprex" class="uri">https://www.tidyverse.org/help/#reprex</a>.</p>
 <p>Brief description of the problem</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" title="1"><span class="co"># insert reprex here</span></a></code></pre></div>
 

--- a/docs/articles/pmdplyr.html
+++ b/docs/articles/pmdplyr.html
@@ -73,7 +73,7 @@
       <h1>pmdplyr: Panel Maneuvers in dplyr</h1>
                         <h4 class="author">Nick Huntington-Klein, Philip Khor</h4>
             
-            <h4 class="date">2019-08-12</h4>
+            <h4 class="date">2019-08-13</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/NickCH-K/pmdplyr/blob/master/vignettes/pmdplyr.Rmd"><code>vignettes/pmdplyr.Rmd</code></a></small>
       <div class="hidden name"><code>pmdplyr.Rmd</code></div>
@@ -253,14 +253,14 @@
 <a class="sourceLine" id="cb7-16" title="16"></a>
 <a class="sourceLine" id="cb7-17" title="17">df</a>
 <a class="sourceLine" id="cb7-18" title="18"><span class="co">#&gt;   country       city numeric_ID random_ID           char_ID</span></a>
-<a class="sourceLine" id="cb7-19" title="19"><span class="co">#&gt; 1      US        NYC          1        11 |US|.|NYC|.......</span></a>
-<a class="sourceLine" id="cb7-20" title="20"><span class="co">#&gt; 2      US        NYC          1        11 |US|.|NYC|.......</span></a>
-<a class="sourceLine" id="cb7-21" title="21"><span class="co">#&gt; 3      US  Cambridge          2        16 |US|.|Cambridge|.</span></a>
-<a class="sourceLine" id="cb7-22" title="22"><span class="co">#&gt; 4      US        NYC          1        11 |US|.|NYC|.......</span></a>
-<a class="sourceLine" id="cb7-23" title="23"><span class="co">#&gt; 5     GBR  Cambridge          3         5 |GBR||Cambridge|.</span></a>
-<a class="sourceLine" id="cb7-24" title="24"><span class="co">#&gt; 6     GBR     London          4        43 |GBR||London|....</span></a>
-<a class="sourceLine" id="cb7-25" title="25"><span class="co">#&gt; 7     GBR Manchester          5        30 |GBR||Manchester|</span></a>
-<a class="sourceLine" id="cb7-26" title="26"><span class="co">#&gt; 8     GBR Manchester          5        30 |GBR||Manchester|</span></a></code></pre></div>
+<a class="sourceLine" id="cb7-19" title="19"><span class="co">#&gt; 1      US        NYC          1        25 |US|.|NYC|.......</span></a>
+<a class="sourceLine" id="cb7-20" title="20"><span class="co">#&gt; 2      US        NYC          1        25 |US|.|NYC|.......</span></a>
+<a class="sourceLine" id="cb7-21" title="21"><span class="co">#&gt; 3      US  Cambridge          2        19 |US|.|Cambridge|.</span></a>
+<a class="sourceLine" id="cb7-22" title="22"><span class="co">#&gt; 4      US        NYC          1        25 |US|.|NYC|.......</span></a>
+<a class="sourceLine" id="cb7-23" title="23"><span class="co">#&gt; 5     GBR  Cambridge          3         7 |GBR||Cambridge|.</span></a>
+<a class="sourceLine" id="cb7-24" title="24"><span class="co">#&gt; 6     GBR     London          4        45 |GBR||London|....</span></a>
+<a class="sourceLine" id="cb7-25" title="25"><span class="co">#&gt; 7     GBR Manchester          5        11 |GBR||Manchester|</span></a>
+<a class="sourceLine" id="cb7-26" title="26"><span class="co">#&gt; 8     GBR Manchester          5        11 |GBR||Manchester|</span></a></code></pre></div>
 </div>
 <div id="time_variable" class="section level2">
 <h2 class="hasAnchor">

--- a/docs/index.html
+++ b/docs/index.html
@@ -229,6 +229,8 @@
 <ul class="list-unstyled">
 <li>Browse source code at <br><a href="https://github.com/NickCH-K/pmdplyr">https://​github.com/​NickCH-K/​pmdplyr</a>
 </li>
+<li>Report a bug at <br><a href="https://github.com/NickCH-K/pmdplyr/issues">https://​github.com/​NickCH-K/​pmdplyr/​issues</a>
+</li>
 </ul>
 </div>
 <div class="license">


### PR DESCRIPTION
Tidyverse packages are usually tested on 
> current release, devel, and four previous versions

This PR ensures that Travis runs the relevant tests for pmdplyr on the aforementioned versions of R using `usethis::use_tidy_ci()`. As a consequence, the minimum R version has been adjusted from R 2.15.1 to R ~3.2~3.4, the minimum tested version. 