### PR TITLE
Add copyright information for SPrail, specifically relicensing SPrail under GPLv2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ Description: Using the 'dplyr' package as a base, adds a family of functions des
 License: MIT + file LICENSE
 URL: https://nickch-k.github.io/pmdplyr, https://github.com/NickCH-K/pmdplyr
 BugReports: https://github.com/NickCH-K/pmdplyr/issues
+Copyright: file COPYRIGHTS
 Encoding: UTF-8
 Depends: 
     R (>= 3.4),

--- a/docs/404.html
+++ b/docs/404.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -95,6 +95,9 @@
       <a href="articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/CODE_OF_CONDUCT.html
+++ b/docs/CODE_OF_CONDUCT.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -95,6 +95,9 @@
       <a href="articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/CONTRIBUTING.html
+++ b/docs/CONTRIBUTING.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -95,6 +95,9 @@
       <a href="articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/ISSUE_TEMPLATE.html
+++ b/docs/ISSUE_TEMPLATE.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -96,6 +96,9 @@
     </li>
   </ul>
 </li>
+<li>
+  <a href="news/index.html">Changelog</a>
+</li>
       </ul>
       
       <ul class="nav navbar-nav navbar-right">
@@ -127,7 +130,7 @@
 <p>Please briefly describe your problem and what output you expect. If you have a question, please don’t use this form. Instead, ask on <a href="https://stackoverflow.com/" class="uri">https://stackoverflow.com/</a> or <a href="https://community.rstudio.com/" class="uri">https://community.rstudio.com/</a>.</p>
 <p>Please include a minimal reproducible example (AKA a reprex). If you’ve never heard of a <a href="http://reprex.tidyverse.org/">reprex</a> before, start by reading <a href="https://www.tidyverse.org/help/#reprex" class="uri">https://www.tidyverse.org/help/#reprex</a>.</p>
 <p>Brief description of the problem</p>
-<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" title="1"><span class="co"># insert reprex here</span></a></code></pre></div>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1"></a><span class="co"># insert reprex here</span></span></code></pre></div>
 
 
   </div>

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -95,6 +95,9 @@
       <a href="articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/SUPPORT.html
+++ b/docs/SUPPORT.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -95,6 +95,9 @@
       <a href="articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -95,6 +95,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -95,6 +95,9 @@
       <a href="articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -63,6 +63,9 @@
       <a href="articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="news/index.html">Changelog</a>
 </li>
       </ul>
 <ul class="nav navbar-nav navbar-right">
@@ -101,91 +104,91 @@
 <h2 class="hasAnchor">
 <a href="#installation" class="anchor"></a>Installation</h2>
 <p>You can install the development version from <a href="https://github.com/">GitHub</a> with:</p>
-<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" title="1"><span class="co"># install.packages("devtools")</span></a>
-<a class="sourceLine" id="cb1-2" title="2">devtools<span class="op">::</span><span class="kw"><a href="https://rdrr.io/pkg/devtools/man/reexports.html">install_github</a></span>(<span class="st">"NickCH-K/pmdplyr"</span>)</a></code></pre></div>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1"></a><span class="co"># install.packages("devtools")</span></span>
+<span id="cb1-2"><a href="#cb1-2"></a>devtools<span class="op">::</span><span class="kw"><a href="https://rdrr.io/pkg/devtools/man/reexports.html">install_github</a></span>(<span class="st">"NickCH-K/pmdplyr"</span>)</span></code></pre></div>
 </div>
 <div id="college-scorecard-example" class="section level2">
 <h2 class="hasAnchor">
 <a href="#college-scorecard-example" class="anchor"></a>College Scorecard Example</h2>
 <p>Let’s start with the fairly straightforward <code>Scorecard</code> data, which describes how well students who attended that college are doing years after attendance. <code>Scorecard</code> observations are uniquely identified by college ID <code>unitid</code> and year <code>year</code>.</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" title="1"><span class="co"># Note that pmdplyr automatically loads dplyr as well</span></a>
-<a class="sourceLine" id="cb2-2" title="2"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(pmdplyr)</a>
-<a class="sourceLine" id="cb2-3" title="3"></a>
-<a class="sourceLine" id="cb2-4" title="4"><span class="kw"><a href="https://rdrr.io/r/utils/data.html">data</a></span>(Scorecard)</a>
-<a class="sourceLine" id="cb2-5" title="5"><span class="co"># Let's declare it as a pibble panel-data tibble</span></a>
-<a class="sourceLine" id="cb2-6" title="6">Scorecard &lt;-<span class="st"> </span><span class="kw"><a href="reference/as_pibble.html">as_pibble</a></span>(Scorecard, <span class="dt">.i =</span> unitid, <span class="dt">.t =</span> year)</a>
-<a class="sourceLine" id="cb2-7" title="7"></a>
-<a class="sourceLine" id="cb2-8" title="8"><span class="co"># We also have this data on the December unemployment rate for US college grads nationally</span></a>
-<a class="sourceLine" id="cb2-9" title="9"><span class="co"># but only every other year</span></a>
-<a class="sourceLine" id="cb2-10" title="10">unemp_data &lt;-<span class="st"> </span><span class="kw"><a href="https://rdrr.io/r/base/data.frame.html">data.frame</a></span>(</a>
-<a class="sourceLine" id="cb2-11" title="11">  <span class="dt">unemp_year =</span> <span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="dv">2006</span>, <span class="dv">2008</span>, <span class="dv">2010</span>, <span class="dv">2012</span>, <span class="dv">2014</span>, <span class="dv">2016</span>, <span class="dv">2018</span>),</a>
-<a class="sourceLine" id="cb2-12" title="12">  <span class="dt">unemp =</span> <span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(.<span class="dv">017</span>, <span class="fl">.036</span>, <span class="fl">.048</span>, <span class="fl">.040</span>, <span class="fl">.028</span>, <span class="fl">.025</span>, <span class="fl">.020</span>)</a>
-<a class="sourceLine" id="cb2-13" title="13">)</a></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb2-1"><a href="#cb2-1"></a><span class="co"># Note that pmdplyr automatically loads dplyr as well</span></span>
+<span id="cb2-2"><a href="#cb2-2"></a><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(pmdplyr)</span>
+<span id="cb2-3"><a href="#cb2-3"></a></span>
+<span id="cb2-4"><a href="#cb2-4"></a><span class="kw"><a href="https://rdrr.io/r/utils/data.html">data</a></span>(Scorecard)</span>
+<span id="cb2-5"><a href="#cb2-5"></a><span class="co"># Let's declare it as a pibble panel-data tibble</span></span>
+<span id="cb2-6"><a href="#cb2-6"></a>Scorecard &lt;-<span class="st"> </span><span class="kw"><a href="reference/as_pibble.html">as_pibble</a></span>(Scorecard, <span class="dt">.i =</span> unitid, <span class="dt">.t =</span> year)</span>
+<span id="cb2-7"><a href="#cb2-7"></a></span>
+<span id="cb2-8"><a href="#cb2-8"></a><span class="co"># We also have this data on the December unemployment rate for US college grads nationally</span></span>
+<span id="cb2-9"><a href="#cb2-9"></a><span class="co"># but only every other year</span></span>
+<span id="cb2-10"><a href="#cb2-10"></a>unemp_data &lt;-<span class="st"> </span><span class="kw"><a href="https://rdrr.io/r/base/data.frame.html">data.frame</a></span>(</span>
+<span id="cb2-11"><a href="#cb2-11"></a>  <span class="dt">unemp_year =</span> <span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="dv">2006</span>, <span class="dv">2008</span>, <span class="dv">2010</span>, <span class="dv">2012</span>, <span class="dv">2014</span>, <span class="dv">2016</span>, <span class="dv">2018</span>),</span>
+<span id="cb2-12"><a href="#cb2-12"></a>  <span class="dt">unemp =</span> <span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(.<span class="dv">017</span>, <span class="fl">.036</span>, <span class="fl">.048</span>, <span class="fl">.040</span>, <span class="fl">.028</span>, <span class="fl">.025</span>, <span class="fl">.020</span>)</span>
+<span id="cb2-13"><a href="#cb2-13"></a>)</span></code></pre></div>
 <p>I am interested in measuring the differences in ex-student earnings <code>earnings_med</code> between two-year and four-year colleges (<code>pred_degree_awarded_ipeds == 2</code> or <code>3</code>, respectively). But before we can do that we need to clean the data.</p>
-<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" title="1">Scorecard <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb3-2" title="2"><span class="st">  </span><span class="co"># We want pred_degree_awarded_ipeds to be consistent within college. No changers!</span></a>
-<a class="sourceLine" id="cb3-3" title="3"><span class="st">  </span><span class="co"># So let's drop them by using fixed_check with .resolve = "drop" to lose inconsistencies</span></a>
-<a class="sourceLine" id="cb3-4" title="4"><span class="st">  </span><span class="kw"><a href="reference/fixed_force.html">fixed_force</a></span>(</a>
-<a class="sourceLine" id="cb3-5" title="5">    <span class="dt">.var =</span> pred_degree_awarded_ipeds,</a>
-<a class="sourceLine" id="cb3-6" title="6">    <span class="dt">.within =</span> unitid,</a>
-<a class="sourceLine" id="cb3-7" title="7">    <span class="dt">.resolve =</span> <span class="st">"drop"</span></a>
-<a class="sourceLine" id="cb3-8" title="8">  ) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb3-9" title="9"><span class="st">  </span><span class="co"># Then, get rid of pred_degree_awarded_ipeds == 1</span></a>
-<a class="sourceLine" id="cb3-10" title="10"><span class="st">  </span><span class="co"># And simplify our terms</span></a>
-<a class="sourceLine" id="cb3-11" title="11"><span class="st">  </span><span class="kw"><a href="https://rdrr.io/r/stats/filter.html">filter</a></span>(pred_degree_awarded_ipeds <span class="op">%in%</span><span class="st"> </span><span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="dv">2</span>, <span class="dv">3</span>)) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb3-12" title="12"><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">FourYear =</span> pred_degree_awarded_ipeds <span class="op">==</span><span class="st"> </span><span class="dv">3</span>) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb3-13" title="13"><span class="st">  </span><span class="co"># earnings_med has some missing values - let's fill them in with</span></a>
-<a class="sourceLine" id="cb3-14" title="14"><span class="st">  </span><span class="co"># the most recent nonmissing observations we have</span></a>
-<a class="sourceLine" id="cb3-15" title="15"><span class="st">  </span><span class="co"># - panel_locf respects the panel structure declared above with as_pibble()</span></a>
-<a class="sourceLine" id="cb3-16" title="16"><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">earnings_med =</span> <span class="kw"><a href="reference/panel_locf.html">panel_locf</a></span>(earnings_med)) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb3-17" title="17"><span class="st">  </span><span class="co"># Now let's bring in that unemployment data!</span></a>
-<a class="sourceLine" id="cb3-18" title="18"><span class="st">  </span><span class="co"># Since it's every other year, it won't line up properly</span></a>
-<a class="sourceLine" id="cb3-19" title="19"><span class="st">  </span><span class="co"># in the join. So let's use inexact_join to get the MOST RECENT</span></a>
-<a class="sourceLine" id="cb3-20" title="20"><span class="st">  </span><span class="co"># year to join with</span></a>
-<a class="sourceLine" id="cb3-21" title="21"><span class="st">  </span><span class="kw"><a href="reference/inexact_join.html">inexact_left_join</a></span>(unemp_data, <span class="dt">var =</span> year, <span class="dt">jvar =</span> unemp_year, <span class="dt">method =</span> <span class="st">"last"</span>) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb3-22" title="22"><span class="st">  </span><span class="co"># To adjust for state-level trends, let's also control for a tlag of</span></a>
-<a class="sourceLine" id="cb3-23" title="23"><span class="st">  </span><span class="co"># average earnings within state.</span></a>
-<a class="sourceLine" id="cb3-24" title="24"><span class="st">  </span><span class="co"># The lag is at the state level, and state-year doesn't uniquely identify,</span></a>
-<a class="sourceLine" id="cb3-25" title="25"><span class="st">  </span><span class="co"># But that's okay! We just pick a .resolve function to handle disagreements.</span></a>
-<a class="sourceLine" id="cb3-26" title="26"><span class="st">  </span><span class="co"># (We could also do this straight in the regression model itself)</span></a>
-<a class="sourceLine" id="cb3-27" title="27"><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">lag_state_earnings =</span> <span class="kw"><a href="reference/tlag.html">tlag</a></span>(earnings_med,</a>
-<a class="sourceLine" id="cb3-28" title="28">    <span class="dt">.i =</span> state_abbr,</a>
-<a class="sourceLine" id="cb3-29" title="29">    <span class="dt">.t =</span> year,</a>
-<a class="sourceLine" id="cb3-30" title="30">    <span class="dt">.resolve =</span> mean</a>
-<a class="sourceLine" id="cb3-31" title="31">  )) -&gt;<span class="st"> </span>scorecard_clean</a>
-<a class="sourceLine" id="cb3-32" title="32"></a>
-<a class="sourceLine" id="cb3-33" title="33"><span class="co"># Now we can run a basic regression.</span></a>
-<a class="sourceLine" id="cb3-34" title="34"></a>
-<a class="sourceLine" id="cb3-35" title="35"><span class="kw"><a href="https://rdrr.io/r/stats/lm.html">lm</a></span>(</a>
-<a class="sourceLine" id="cb3-36" title="36">  earnings_med <span class="op">~</span></a>
-<a class="sourceLine" id="cb3-37" title="37"><span class="st">  </span>FourYear <span class="op">+</span></a>
-<a class="sourceLine" id="cb3-38" title="38"><span class="st">    </span>unemp <span class="op">+</span></a>
-<a class="sourceLine" id="cb3-39" title="39"><span class="st">    </span>lag_state_earnings,</a>
-<a class="sourceLine" id="cb3-40" title="40">  <span class="dt">data =</span> scorecard_clean</a>
-<a class="sourceLine" id="cb3-41" title="41">) <span class="op">%&gt;%</span><span class="st"> </span></a>
-<a class="sourceLine" id="cb3-42" title="42"><span class="st">  </span><span class="kw"><a href="https://rdrr.io/r/base/summary.html">summary</a></span>()</a>
-<a class="sourceLine" id="cb3-43" title="43"><span class="co">#&gt; </span></a>
-<a class="sourceLine" id="cb3-44" title="44"><span class="co">#&gt; Call:</span></a>
-<a class="sourceLine" id="cb3-45" title="45"><span class="co">#&gt; lm(formula = earnings_med ~ FourYear + unemp + lag_state_earnings, </span></a>
-<a class="sourceLine" id="cb3-46" title="46"><span class="co">#&gt;     data = scorecard_clean)</span></a>
-<a class="sourceLine" id="cb3-47" title="47"><span class="co">#&gt; </span></a>
-<a class="sourceLine" id="cb3-48" title="48"><span class="co">#&gt; Residuals:</span></a>
-<a class="sourceLine" id="cb3-49" title="49"><span class="co">#&gt;    Min     1Q Median     3Q    Max </span></a>
-<a class="sourceLine" id="cb3-50" title="50"><span class="co">#&gt; -25341  -4917   -528   4091  54587 </span></a>
-<a class="sourceLine" id="cb3-51" title="51"><span class="co">#&gt; </span></a>
-<a class="sourceLine" id="cb3-52" title="52"><span class="co">#&gt; Coefficients:</span></a>
-<a class="sourceLine" id="cb3-53" title="53"><span class="co">#&gt;                      Estimate Std. Error t value Pr(&gt;|t|)    </span></a>
-<a class="sourceLine" id="cb3-54" title="54"><span class="co">#&gt; (Intercept)         5.933e+03  1.772e+03   3.348 0.000826 ***</span></a>
-<a class="sourceLine" id="cb3-55" title="55"><span class="co">#&gt; FourYearTRUE        9.088e+03  3.511e+02  25.886  &lt; 2e-16 ***</span></a>
-<a class="sourceLine" id="cb3-56" title="56"><span class="co">#&gt; unemp              -4.564e+04  2.529e+04  -1.805 0.071215 .  </span></a>
-<a class="sourceLine" id="cb3-57" title="57"><span class="co">#&gt; lag_state_earnings  7.348e-01  4.027e-02  18.244  &lt; 2e-16 ***</span></a>
-<a class="sourceLine" id="cb3-58" title="58"><span class="co">#&gt; ---</span></a>
-<a class="sourceLine" id="cb3-59" title="59"><span class="co">#&gt; Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1</span></a>
-<a class="sourceLine" id="cb3-60" title="60"><span class="co">#&gt; </span></a>
-<a class="sourceLine" id="cb3-61" title="61"><span class="co">#&gt; Residual standard error: 8209 on 2474 degrees of freedom</span></a>
-<a class="sourceLine" id="cb3-62" title="62"><span class="co">#&gt;   (25161 observations deleted due to missingness)</span></a>
-<a class="sourceLine" id="cb3-63" title="63"><span class="co">#&gt; Multiple R-squared:  0.3431, Adjusted R-squared:  0.3423 </span></a>
-<a class="sourceLine" id="cb3-64" title="64"><span class="co">#&gt; F-statistic: 430.6 on 3 and 2474 DF,  p-value: &lt; 2.2e-16</span></a></code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb3-1"><a href="#cb3-1"></a>Scorecard <span class="op">%&gt;%</span></span>
+<span id="cb3-2"><a href="#cb3-2"></a><span class="st">  </span><span class="co"># We want pred_degree_awarded_ipeds to be consistent within college. No changers!</span></span>
+<span id="cb3-3"><a href="#cb3-3"></a><span class="st">  </span><span class="co"># So let's drop them by using fixed_check with .resolve = "drop" to lose inconsistencies</span></span>
+<span id="cb3-4"><a href="#cb3-4"></a><span class="st">  </span><span class="kw"><a href="reference/fixed_force.html">fixed_force</a></span>(</span>
+<span id="cb3-5"><a href="#cb3-5"></a>    <span class="dt">.var =</span> pred_degree_awarded_ipeds,</span>
+<span id="cb3-6"><a href="#cb3-6"></a>    <span class="dt">.within =</span> unitid,</span>
+<span id="cb3-7"><a href="#cb3-7"></a>    <span class="dt">.resolve =</span> <span class="st">"drop"</span></span>
+<span id="cb3-8"><a href="#cb3-8"></a>  ) <span class="op">%&gt;%</span></span>
+<span id="cb3-9"><a href="#cb3-9"></a><span class="st">  </span><span class="co"># Then, get rid of pred_degree_awarded_ipeds == 1</span></span>
+<span id="cb3-10"><a href="#cb3-10"></a><span class="st">  </span><span class="co"># And simplify our terms</span></span>
+<span id="cb3-11"><a href="#cb3-11"></a><span class="st">  </span><span class="kw"><a href="https://rdrr.io/r/stats/filter.html">filter</a></span>(pred_degree_awarded_ipeds <span class="op">%in%</span><span class="st"> </span><span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="dv">2</span>, <span class="dv">3</span>)) <span class="op">%&gt;%</span></span>
+<span id="cb3-12"><a href="#cb3-12"></a><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">FourYear =</span> pred_degree_awarded_ipeds <span class="op">==</span><span class="st"> </span><span class="dv">3</span>) <span class="op">%&gt;%</span></span>
+<span id="cb3-13"><a href="#cb3-13"></a><span class="st">  </span><span class="co"># earnings_med has some missing values - let's fill them in with</span></span>
+<span id="cb3-14"><a href="#cb3-14"></a><span class="st">  </span><span class="co"># the most recent nonmissing observations we have</span></span>
+<span id="cb3-15"><a href="#cb3-15"></a><span class="st">  </span><span class="co"># - panel_locf respects the panel structure declared above with as_pibble()</span></span>
+<span id="cb3-16"><a href="#cb3-16"></a><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">earnings_med =</span> <span class="kw"><a href="reference/panel_locf.html">panel_locf</a></span>(earnings_med)) <span class="op">%&gt;%</span></span>
+<span id="cb3-17"><a href="#cb3-17"></a><span class="st">  </span><span class="co"># Now let's bring in that unemployment data!</span></span>
+<span id="cb3-18"><a href="#cb3-18"></a><span class="st">  </span><span class="co"># Since it's every other year, it won't line up properly</span></span>
+<span id="cb3-19"><a href="#cb3-19"></a><span class="st">  </span><span class="co"># in the join. So let's use inexact_join to get the MOST RECENT</span></span>
+<span id="cb3-20"><a href="#cb3-20"></a><span class="st">  </span><span class="co"># year to join with</span></span>
+<span id="cb3-21"><a href="#cb3-21"></a><span class="st">  </span><span class="kw"><a href="reference/inexact_join.html">inexact_left_join</a></span>(unemp_data, <span class="dt">var =</span> year, <span class="dt">jvar =</span> unemp_year, <span class="dt">method =</span> <span class="st">"last"</span>) <span class="op">%&gt;%</span></span>
+<span id="cb3-22"><a href="#cb3-22"></a><span class="st">  </span><span class="co"># To adjust for state-level trends, let's also control for a tlag of</span></span>
+<span id="cb3-23"><a href="#cb3-23"></a><span class="st">  </span><span class="co"># average earnings within state.</span></span>
+<span id="cb3-24"><a href="#cb3-24"></a><span class="st">  </span><span class="co"># The lag is at the state level, and state-year doesn't uniquely identify,</span></span>
+<span id="cb3-25"><a href="#cb3-25"></a><span class="st">  </span><span class="co"># But that's okay! We just pick a .resolve function to handle disagreements.</span></span>
+<span id="cb3-26"><a href="#cb3-26"></a><span class="st">  </span><span class="co"># (We could also do this straight in the regression model itself)</span></span>
+<span id="cb3-27"><a href="#cb3-27"></a><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">lag_state_earnings =</span> <span class="kw"><a href="reference/tlag.html">tlag</a></span>(earnings_med,</span>
+<span id="cb3-28"><a href="#cb3-28"></a>    <span class="dt">.i =</span> state_abbr,</span>
+<span id="cb3-29"><a href="#cb3-29"></a>    <span class="dt">.t =</span> year,</span>
+<span id="cb3-30"><a href="#cb3-30"></a>    <span class="dt">.resolve =</span> mean</span>
+<span id="cb3-31"><a href="#cb3-31"></a>  )) -&gt;<span class="st"> </span>scorecard_clean</span>
+<span id="cb3-32"><a href="#cb3-32"></a></span>
+<span id="cb3-33"><a href="#cb3-33"></a><span class="co"># Now we can run a basic regression.</span></span>
+<span id="cb3-34"><a href="#cb3-34"></a></span>
+<span id="cb3-35"><a href="#cb3-35"></a><span class="kw"><a href="https://rdrr.io/r/stats/lm.html">lm</a></span>(</span>
+<span id="cb3-36"><a href="#cb3-36"></a>  earnings_med <span class="op">~</span></span>
+<span id="cb3-37"><a href="#cb3-37"></a><span class="st">  </span>FourYear <span class="op">+</span></span>
+<span id="cb3-38"><a href="#cb3-38"></a><span class="st">    </span>unemp <span class="op">+</span></span>
+<span id="cb3-39"><a href="#cb3-39"></a><span class="st">    </span>lag_state_earnings,</span>
+<span id="cb3-40"><a href="#cb3-40"></a>  <span class="dt">data =</span> scorecard_clean</span>
+<span id="cb3-41"><a href="#cb3-41"></a>) <span class="op">%&gt;%</span><span class="st"> </span></span>
+<span id="cb3-42"><a href="#cb3-42"></a><span class="st">  </span><span class="kw"><a href="https://rdrr.io/r/base/summary.html">summary</a></span>()</span>
+<span id="cb3-43"><a href="#cb3-43"></a><span class="co">#&gt; </span></span>
+<span id="cb3-44"><a href="#cb3-44"></a><span class="co">#&gt; Call:</span></span>
+<span id="cb3-45"><a href="#cb3-45"></a><span class="co">#&gt; lm(formula = earnings_med ~ FourYear + unemp + lag_state_earnings, </span></span>
+<span id="cb3-46"><a href="#cb3-46"></a><span class="co">#&gt;     data = scorecard_clean)</span></span>
+<span id="cb3-47"><a href="#cb3-47"></a><span class="co">#&gt; </span></span>
+<span id="cb3-48"><a href="#cb3-48"></a><span class="co">#&gt; Residuals:</span></span>
+<span id="cb3-49"><a href="#cb3-49"></a><span class="co">#&gt;    Min     1Q Median     3Q    Max </span></span>
+<span id="cb3-50"><a href="#cb3-50"></a><span class="co">#&gt; -25341  -4917   -528   4091  54587 </span></span>
+<span id="cb3-51"><a href="#cb3-51"></a><span class="co">#&gt; </span></span>
+<span id="cb3-52"><a href="#cb3-52"></a><span class="co">#&gt; Coefficients:</span></span>
+<span id="cb3-53"><a href="#cb3-53"></a><span class="co">#&gt;                      Estimate Std. Error t value Pr(&gt;|t|)    </span></span>
+<span id="cb3-54"><a href="#cb3-54"></a><span class="co">#&gt; (Intercept)         5.933e+03  1.772e+03   3.348 0.000826 ***</span></span>
+<span id="cb3-55"><a href="#cb3-55"></a><span class="co">#&gt; FourYearTRUE        9.088e+03  3.511e+02  25.886  &lt; 2e-16 ***</span></span>
+<span id="cb3-56"><a href="#cb3-56"></a><span class="co">#&gt; unemp              -4.564e+04  2.529e+04  -1.805 0.071215 .  </span></span>
+<span id="cb3-57"><a href="#cb3-57"></a><span class="co">#&gt; lag_state_earnings  7.348e-01  4.027e-02  18.244  &lt; 2e-16 ***</span></span>
+<span id="cb3-58"><a href="#cb3-58"></a><span class="co">#&gt; ---</span></span>
+<span id="cb3-59"><a href="#cb3-59"></a><span class="co">#&gt; Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1</span></span>
+<span id="cb3-60"><a href="#cb3-60"></a><span class="co">#&gt; </span></span>
+<span id="cb3-61"><a href="#cb3-61"></a><span class="co">#&gt; Residual standard error: 8209 on 2474 degrees of freedom</span></span>
+<span id="cb3-62"><a href="#cb3-62"></a><span class="co">#&gt;   (25161 observations deleted due to missingness)</span></span>
+<span id="cb3-63"><a href="#cb3-63"></a><span class="co">#&gt; Multiple R-squared:  0.3431, Adjusted R-squared:  0.3423 </span></span>
+<span id="cb3-64"><a href="#cb3-64"></a><span class="co">#&gt; F-statistic: 430.6 on 3 and 2474 DF,  p-value: &lt; 2.2e-16</span></span></code></pre></div>
 <p>We could even improve that code - why not run the <code>anti_join()</code> and <code><a href="reference/inexact_join.html">inexact_left_join()</a></code> using <code><a href="reference/safe_join.html">safe_join()</a></code>? When we do the <code><a href="reference/inexact_join.html">inexact_left_join()</a></code>, for example, we’re assuming that <code>unemp_data</code> is uniquely identified by <code>unemp_year</code>—is it really? <code><a href="reference/safe_join.html">safe_join()</a></code> would check for us and minimize error.</p>
 </div>
 <div id="spanish-rail-example" class="section level2">
@@ -194,43 +197,43 @@
 <p>Let’s shift focus to the <code>SPrail</code> data set, which is not nearly as well behaved as <code>Scorecard</code>! This data contains the <code>price</code> of 2,000 train trips taken on the Spanish rail system. At any given time period, there are multiple tickets sold per route, which is identified by <code>origin</code> and <code>destination</code>. And the <code>insert_date</code> of sale is down to the minute - far more precise than we might actually want to use.</p>
 <p>Let’s say we are interested in how much of a premium you’ll have to pay for different ticket types relative to the cheapo option - a tourist ticket with a transfer (<code>train_class == "Turista con enlace"</code>), accounting for differences in prices between routes.</p>
 <p>We have some difficulties to cover: making the ID and time variables behave, accounting for the between-route differences, and figuring out how to compare each price to the cheapo price.</p>
-<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" title="1"><span class="kw"><a href="https://rdrr.io/r/utils/data.html">data</a></span>(SPrail)</a>
-<a class="sourceLine" id="cb4-2" title="2"></a>
-<a class="sourceLine" id="cb4-3" title="3">SPrail <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb4-4" title="4"><span class="st">  </span><span class="co"># We have two ID variables - origin and destination.</span></a>
-<a class="sourceLine" id="cb4-5" title="5"><span class="st">  </span><span class="co"># pmdplyr has no problem with this, but maybe we want to export</span></a>
-<a class="sourceLine" id="cb4-6" title="6"><span class="st">  </span><span class="co"># to something like plm later, which can't handle it.</span></a>
-<a class="sourceLine" id="cb4-7" title="7"><span class="st">  </span><span class="co"># So let's use id_variable to combine them into one</span></a>
-<a class="sourceLine" id="cb4-8" title="8"><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">route_ID =</span> <span class="kw"><a href="reference/id_variable.html">id_variable</a></span>(origin, destination)) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb4-9" title="9"><span class="st">  </span><span class="co"># We have a time variable down to the minute. Too fine-grained!</span></a>
-<a class="sourceLine" id="cb4-10" title="10"><span class="st">  </span><span class="co"># Let's back things up to the daily level, and</span></a>
-<a class="sourceLine" id="cb4-11" title="11"><span class="st">  </span><span class="co"># create a nice integer time variable that's easy to use</span></a>
-<a class="sourceLine" id="cb4-12" title="12"><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">day =</span> <span class="kw"><a href="reference/time_variable.html">time_variable</a></span>(insert_date, <span class="dt">.method =</span> <span class="st">"day"</span>)) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb4-13" title="13"><span class="st">  </span><span class="co"># Now we can declare a pibble</span></a>
-<a class="sourceLine" id="cb4-14" title="14"><span class="st">  </span><span class="kw"><a href="reference/as_pibble.html">as_pibble</a></span>(<span class="dt">.i =</span> route_ID, <span class="dt">.t =</span> day) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb4-15" title="15"><span class="st">  </span><span class="co"># We want to account for between-route differences in price,</span></a>
-<a class="sourceLine" id="cb4-16" title="16"><span class="st">  </span><span class="co"># so let's isolate the within variation</span></a>
-<a class="sourceLine" id="cb4-17" title="17"><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">price_w =</span> <span class="kw"><a href="reference/panel_calculations.html">within_i</a></span>(price)) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb4-18" title="18"><span class="st">  </span><span class="co"># We want to compare to the cheapo option, so let's use</span></a>
-<a class="sourceLine" id="cb4-19" title="19"><span class="st">  </span><span class="co"># mutate_subset to get the average price of the cheapo option</span></a>
-<a class="sourceLine" id="cb4-20" title="20"><span class="st">  </span><span class="co"># and propogate that to the other options for comparison</span></a>
-<a class="sourceLine" id="cb4-21" title="21"><span class="st">  </span><span class="kw"><a href="reference/mutate_subset.html">mutate_subset</a></span>(</a>
-<a class="sourceLine" id="cb4-22" title="22">    <span class="dt">cheapo_price =</span> <span class="kw"><a href="https://rdrr.io/r/base/mean.html">mean</a></span>(price, <span class="dt">na.rm =</span> <span class="ot">TRUE</span>),</a>
-<a class="sourceLine" id="cb4-23" title="23">    <span class="dt">.filter =</span> train_class <span class="op">==</span><span class="st"> "Turista con enlace"</span></a>
-<a class="sourceLine" id="cb4-24" title="24">  ) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb4-25" title="25"><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">premium =</span> price <span class="op">-</span><span class="st"> </span>cheapo_price) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb4-26" title="26"><span class="st">  </span><span class="kw"><a href="https://rdrr.io/r/stats/filter.html">filter</a></span>(train_class <span class="op">%in%</span><span class="st"> </span><span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"Preferente"</span>, <span class="st">"Turista"</span>, <span class="st">"Turista Plus"</span>)) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb4-27" title="27"><span class="st">  </span><span class="co"># Now let's compare premia</span></a>
-<a class="sourceLine" id="cb4-28" title="28"><span class="st">  </span><span class="kw">group_by</span>(train_class) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb4-29" title="29"><span class="st">  </span><span class="kw">summarize</span>(<span class="dt">premium =</span> <span class="kw"><a href="https://rdrr.io/r/base/mean.html">mean</a></span>(premium, <span class="dt">na.rm =</span> <span class="ot">TRUE</span>)) -&gt;<span class="st"> </span>sprail_compare_premia</a>
-<a class="sourceLine" id="cb4-30" title="30"></a>
-<a class="sourceLine" id="cb4-31" title="31">sprail_compare_premia</a>
-<a class="sourceLine" id="cb4-32" title="32"><span class="co">#&gt; # A tibble: 3 x 2</span></a>
-<a class="sourceLine" id="cb4-33" title="33"><span class="co">#&gt;   train_class  premium</span></a>
-<a class="sourceLine" id="cb4-34" title="34"><span class="co">#&gt;   &lt;fct&gt;          &lt;dbl&gt;</span></a>
-<a class="sourceLine" id="cb4-35" title="35"><span class="co">#&gt; 1 Preferente     29.9 </span></a>
-<a class="sourceLine" id="cb4-36" title="36"><span class="co">#&gt; 2 Turista         8.36</span></a>
-<a class="sourceLine" id="cb4-37" title="37"><span class="co">#&gt; 3 Turista Plus   14.4</span></a></code></pre></div>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb4-1"><a href="#cb4-1"></a><span class="kw"><a href="https://rdrr.io/r/utils/data.html">data</a></span>(SPrail)</span>
+<span id="cb4-2"><a href="#cb4-2"></a></span>
+<span id="cb4-3"><a href="#cb4-3"></a>SPrail <span class="op">%&gt;%</span></span>
+<span id="cb4-4"><a href="#cb4-4"></a><span class="st">  </span><span class="co"># We have two ID variables - origin and destination.</span></span>
+<span id="cb4-5"><a href="#cb4-5"></a><span class="st">  </span><span class="co"># pmdplyr has no problem with this, but maybe we want to export</span></span>
+<span id="cb4-6"><a href="#cb4-6"></a><span class="st">  </span><span class="co"># to something like plm later, which can't handle it.</span></span>
+<span id="cb4-7"><a href="#cb4-7"></a><span class="st">  </span><span class="co"># So let's use id_variable to combine them into one</span></span>
+<span id="cb4-8"><a href="#cb4-8"></a><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">route_ID =</span> <span class="kw"><a href="reference/id_variable.html">id_variable</a></span>(origin, destination)) <span class="op">%&gt;%</span></span>
+<span id="cb4-9"><a href="#cb4-9"></a><span class="st">  </span><span class="co"># We have a time variable down to the minute. Too fine-grained!</span></span>
+<span id="cb4-10"><a href="#cb4-10"></a><span class="st">  </span><span class="co"># Let's back things up to the daily level, and</span></span>
+<span id="cb4-11"><a href="#cb4-11"></a><span class="st">  </span><span class="co"># create a nice integer time variable that's easy to use</span></span>
+<span id="cb4-12"><a href="#cb4-12"></a><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">day =</span> <span class="kw"><a href="reference/time_variable.html">time_variable</a></span>(insert_date, <span class="dt">.method =</span> <span class="st">"day"</span>)) <span class="op">%&gt;%</span></span>
+<span id="cb4-13"><a href="#cb4-13"></a><span class="st">  </span><span class="co"># Now we can declare a pibble</span></span>
+<span id="cb4-14"><a href="#cb4-14"></a><span class="st">  </span><span class="kw"><a href="reference/as_pibble.html">as_pibble</a></span>(<span class="dt">.i =</span> route_ID, <span class="dt">.t =</span> day) <span class="op">%&gt;%</span></span>
+<span id="cb4-15"><a href="#cb4-15"></a><span class="st">  </span><span class="co"># We want to account for between-route differences in price,</span></span>
+<span id="cb4-16"><a href="#cb4-16"></a><span class="st">  </span><span class="co"># so let's isolate the within variation</span></span>
+<span id="cb4-17"><a href="#cb4-17"></a><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">price_w =</span> <span class="kw"><a href="reference/panel_calculations.html">within_i</a></span>(price)) <span class="op">%&gt;%</span></span>
+<span id="cb4-18"><a href="#cb4-18"></a><span class="st">  </span><span class="co"># We want to compare to the cheapo option, so let's use</span></span>
+<span id="cb4-19"><a href="#cb4-19"></a><span class="st">  </span><span class="co"># mutate_subset to get the average price of the cheapo option</span></span>
+<span id="cb4-20"><a href="#cb4-20"></a><span class="st">  </span><span class="co"># and propogate that to the other options for comparison</span></span>
+<span id="cb4-21"><a href="#cb4-21"></a><span class="st">  </span><span class="kw"><a href="reference/mutate_subset.html">mutate_subset</a></span>(</span>
+<span id="cb4-22"><a href="#cb4-22"></a>    <span class="dt">cheapo_price =</span> <span class="kw"><a href="https://rdrr.io/r/base/mean.html">mean</a></span>(price, <span class="dt">na.rm =</span> <span class="ot">TRUE</span>),</span>
+<span id="cb4-23"><a href="#cb4-23"></a>    <span class="dt">.filter =</span> train_class <span class="op">==</span><span class="st"> "Turista con enlace"</span></span>
+<span id="cb4-24"><a href="#cb4-24"></a>  ) <span class="op">%&gt;%</span></span>
+<span id="cb4-25"><a href="#cb4-25"></a><span class="st">  </span><span class="kw">mutate</span>(<span class="dt">premium =</span> price <span class="op">-</span><span class="st"> </span>cheapo_price) <span class="op">%&gt;%</span></span>
+<span id="cb4-26"><a href="#cb4-26"></a><span class="st">  </span><span class="kw"><a href="https://rdrr.io/r/stats/filter.html">filter</a></span>(train_class <span class="op">%in%</span><span class="st"> </span><span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"Preferente"</span>, <span class="st">"Turista"</span>, <span class="st">"Turista Plus"</span>)) <span class="op">%&gt;%</span></span>
+<span id="cb4-27"><a href="#cb4-27"></a><span class="st">  </span><span class="co"># Now let's compare premia</span></span>
+<span id="cb4-28"><a href="#cb4-28"></a><span class="st">  </span><span class="kw">group_by</span>(train_class) <span class="op">%&gt;%</span></span>
+<span id="cb4-29"><a href="#cb4-29"></a><span class="st">  </span><span class="kw">summarize</span>(<span class="dt">premium =</span> <span class="kw"><a href="https://rdrr.io/r/base/mean.html">mean</a></span>(premium, <span class="dt">na.rm =</span> <span class="ot">TRUE</span>)) -&gt;<span class="st"> </span>sprail_compare_premia</span>
+<span id="cb4-30"><a href="#cb4-30"></a></span>
+<span id="cb4-31"><a href="#cb4-31"></a>sprail_compare_premia</span>
+<span id="cb4-32"><a href="#cb4-32"></a><span class="co">#&gt; # A tibble: 3 x 2</span></span>
+<span id="cb4-33"><a href="#cb4-33"></a><span class="co">#&gt;   train_class  premium</span></span>
+<span id="cb4-34"><a href="#cb4-34"></a><span class="co">#&gt;   &lt;fct&gt;          &lt;dbl&gt;</span></span>
+<span id="cb4-35"><a href="#cb4-35"></a><span class="co">#&gt; 1 Preferente     29.9 </span></span>
+<span id="cb4-36"><a href="#cb4-36"></a><span class="co">#&gt; 2 Turista         8.36</span></span>
+<span id="cb4-37"><a href="#cb4-37"></a><span class="co">#&gt; 3 Turista Plus   14.4</span></span></code></pre></div>
 <p>And so there we have it—<code>Preferente</code> will really set you back relative to the cheapo ticket on the same route.</p>
 <hr>
 <p>Please note that the ‘pmdplyr’ project is released with a <a href="CODE_OF_CONDUCT.html">Contributor Code of Conduct</a>. By contributing to this project, you agree to abide by its terms.</p>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,4 +1,4 @@
-pandoc: '2.6'
+pandoc: 2.7.3
 pkgdown: 1.3.0.9100
 pkgdown_sha: 1829398a4e97056fe7fb332d0e8b952784b49321
 articles:

--- a/docs/reference/SPrail.html
+++ b/docs/reference/SPrail.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/Scorecard.html
+++ b/docs/reference/Scorecard.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/as_pibble.html
+++ b/docs/reference/as_pibble.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/build_pibble.html
+++ b/docs/reference/build_pibble.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/fixed_check.html
+++ b/docs/reference/fixed_check.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/fixed_force.html
+++ b/docs/reference/fixed_force.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/id_variable.html
+++ b/docs/reference/id_variable.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -95,6 +95,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/inexact_join.html
+++ b/docs/reference/inexact_join.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/is_pibble.html
+++ b/docs/reference/is_pibble.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/join.html
+++ b/docs/reference/join.html
@@ -67,7 +67,7 @@ complete documentation." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -99,6 +99,9 @@ complete documentation." />
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/mode_order.html
+++ b/docs/reference/mode_order.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/mutate_cascade.html
+++ b/docs/reference/mutate_cascade.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/mutate_subset.html
+++ b/docs/reference/mutate_subset.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/panel_calculations.html
+++ b/docs/reference/panel_calculations.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/panel_convert.html
+++ b/docs/reference/panel_convert.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/panel_fill.html
+++ b/docs/reference/panel_fill.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/panel_locf.html
+++ b/docs/reference/panel_locf.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/pibble.html
+++ b/docs/reference/pibble.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/pibble_methods.html
+++ b/docs/reference/pibble_methods.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/pipe.html
+++ b/docs/reference/pipe.html
@@ -67,7 +67,7 @@ See magrittr::pipe for details." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -99,6 +99,9 @@ See magrittr::pipe for details." />
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/pmdplyr.html
+++ b/docs/reference/pmdplyr.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/safe_join.html
+++ b/docs/reference/safe_join.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/setops.html
+++ b/docs/reference/setops.html
@@ -67,7 +67,7 @@ join pibbles. See  setops for details." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -99,6 +99,9 @@ join pibbles. See  setops for details." />
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/time_variable.html
+++ b/docs/reference/time_variable.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/docs/reference/tlag.html
+++ b/docs/reference/tlag.html
@@ -66,7 +66,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">pmdplyr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9010</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.2.1.9012</span>
       </span>
     </div>
 
@@ -98,6 +98,9 @@
       <a href="../articles/panel_tools.html">pmdplyr: Panel Tools</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       

--- a/inst/COPYRIGHTS
+++ b/inst/COPYRIGHTS
@@ -1,0 +1,49 @@
+This package is provided you under the terms of the MIT License.
+
+Included below is license and copyright information for data used in pmdplyr. 
+====
+
+SPrail is licensed for use as follows: 
+
+/* The original version of SPrail is licensed under the GPLv2: 
+
+Spanish High Speed Rail tickets pricing - Renfe
+Copyright (C) 2019 The Gurus 
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+/* Modifications to the above are licensed under GPLv2, 
+and includes the following modifications: 
+2,000 observations sampled 
+
+2,000 Spanish train trips
+Copyright (C) 2019 Nick Huntington-Klein
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/ 
+====


### PR DESCRIPTION
This draws heavily on vroom's COPYRIGHTS file, closing #38 by adding a inst/COPYRIGHTS file disclosing GPLv2 license and rebuilds site

Not entirely sure if this is the right thing to do, as I couldn't find an example of a package bundling licensed data. But I think this should satisfy CRAN. 